### PR TITLE
Option to keep items deleted in todoist locally in the org file

### DIFF
--- a/org-todoist.el
+++ b/org-todoist.el
@@ -835,9 +835,6 @@ Use this when pushing updates (we don't want to send id=default) to Todoist."
                (oldcomments (org-todoist--get-comments-text oldtask)))
           (unless (org-todoist--is-ignored hl)
 
-            (when (or (s-contains? "&" desc) (--any? (s-contains? "&" it) comments))
-              (error "ERROR in org-todoist: Comments and description elements currently cannot contain the ampersand (\"&\") character. See issue #9 on GitHub https://github.com/lillenne/org-todoist"))
-
             ;; new object. Create temp id
             (unless id
               (setq id (org-id-uuid))


### PR DESCRIPTION
(Unrelated) remove error from including ampersands (fixed issue in 9331e8f but did not remove the error when the char is detected in a comment)
Optionally mark deleted nodes as ignored and leave them in the tree
New var 'org-todoist-extract-deleted' to control the behavior